### PR TITLE
Hardcode assignees instead of group in the create issue action

### DIFF
--- a/.github/release_new_npm_package_template.md
+++ b/.github/release_new_npm_package_template.md
@@ -1,6 +1,6 @@
 ---
 title: Biweekly release of the new npm package
-assignees: "safe-global/safe-protocol"
+assignees: mmv08,nlordell,rmeissner,akshay-ap,remedcu
 ---
 
 It's time to release the new version to NPM. Before releasing, please:


### PR DESCRIPTION
The scheduled action to create an issue failed: https://github.com/safe-global/safe-singleton-factory/actions/runs/6872032701.

It did fail in my test run, but I thought it was because my repo doesn't have a `safe-global/safe-protocol` team. Turns out it doesn't work at all. This fixes it by hardcoding assignees as documented in the action docs: https://github.com/JasonEtco/create-an-issue.