### PR TITLE
Update the message that asks for a pre-fund

### DIFF
--- a/.github/scripts/validate_new_chain_request.sh
+++ b/.github/scripts/validate_new_chain_request.sh
@@ -46,7 +46,7 @@ SUCCESS_MSG=\
 "- The deployer address is pre-funded<br>"\
 ":sparkles: The team will be in touch with you soon :sparkles:"
 ADDRESS_NOT_PREFUNDED_ERR_MSG() {
-    echo "**⛔️ Error:**<br/>The deployer address is not pre-funded. Please send $1 wei to $FACTORY_DEPLOYER_ADDRESS and try again."
+    echo "**💸 Pre-fund needed:**<br/>We need a pre-fund to deploy the factory. Please send $1 wei to $FACTORY_DEPLOYER_ADDRESS and check the checkbox in the issue."
 }
 FACTORY_ALREADY_DEPLOYED_ERR_MSG="**⛔️ Error:**<br/>The factory is already deployed. Please use the existing factory at $FACTORY_ADDRESS."
 


### PR DESCRIPTION
This PR:
- Updates the message that asks for a pre-fund, not to include the word "error". The rationale is that we ask the user for the pre-fund after validating the rpc and chainlists, and they don't see the address before. Therefore, it's incorrect to say that there was an error.