### PR TITLE
Check for an empty string when retrieving factory code

### DIFF
--- a/.github/scripts/validate_new_chain_request.sh
+++ b/.github/scripts/validate_new_chain_request.sh
@@ -99,7 +99,7 @@ factory_code=$(curl "$rpc_url" --location --header \
 if jq -e . >/dev/null 2>&1 <<< "$factory_code"; then
   factory_code=$(jq -r '.result' <<< "$factory_code")
 
-  if [ "$factory_code" != "0x" ]; then
+  if [ "$factory_code" != "0x" ] && [ "$factory_code" != "" ]; then
     echo "COMMENT_OUTPUT=$FACTORY_ALREADY_DEPLOYED_ERR_MSG" >> $GITHUB_ENV
     exit 1
   fi


### PR DESCRIPTION
This should fix the issue in https://github.com/safe-global/safe-singleton-factory/actions/runs/7124431253/job/19398662307 where the RPC returns an empty string instead of an empty hex data ("0x")