### PR TITLE
Make mmv08 the only issue assignee, add a workflow_dispatch trigger for debugging

### DIFF
--- a/.github/release_new_npm_package_template.md
+++ b/.github/release_new_npm_package_template.md
@@ -1,6 +1,6 @@
 ---
 title: Biweekly release of the new npm package
-assignees: mmv08,nlordell,rmeissner,akshay-ap,remedcu
+assignees: mmv08
 ---
 
 It's time to release the new version to NPM. Before releasing, please:

--- a/.github/workflows/create-release-issue.yml
+++ b/.github/workflows/create-release-issue.yml
@@ -3,6 +3,7 @@ on:
     # * is a special character in YAML so you have to quote this string
     # There's no direct way to schedule the job run every 2 weeks, instead we schedule it on the 1st and 15th of every month. The trick is taken from https://stackoverflow.com/a/46233330/7820085
     - cron: "30 1 1,15 * *"
+  workflow_dispatch:
 
 name: Create an issue to release the NPM package
 permissions:


### PR DESCRIPTION
It seems that something is wrong with the action that creates a recurring issue to deploy the package to npm. It doesn't like the list of assignees. I suspect that it could be due to some of the people not having access to the repo. In the meantime, I removed all the assignees and only left myself to see if it works.

I also added a `workflow_dispatch` trigger for debugging.