### PR TITLE
Add Script for Verifying Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,10 @@ To submit a transaction after the deployment data is created:
 
 - Set `MNEMONIC` or `PK` in the `.env` file
 - Run `yarn compile:zk`
+
+## Verifying Networks
+
+In order to verify deployments (when reviewing PRs for example), you can use the `verify` script:
+
+- Set `RPC` in the `.env` file for the network.
+- Run `yarn verify`

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "compile": "ts-node scripts/compile.ts",
     "compile:zk": "hardhat compile && hardhat deploy-zksync --script compile-zk.ts",
+    "verify": "ts-node scripts/verify.ts",
     "status": "ts-node scripts/status.ts",
     "submit": "ts-node scripts/submit.ts",
     "estimate": "ts-node scripts/estimate.ts",

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -1,0 +1,28 @@
+import { promises as filesystem } from 'fs'
+import * as path from 'path'
+import { ethers } from 'ethers'
+import dotenv from "dotenv";
+import { runScript } from './utils';
+
+dotenv.config()
+
+const CODEHASH = "0x2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989"
+
+async function verifyDeploymentCode() {
+	const rpcUrl = process.env.RPC
+	const provider = new ethers.providers.JsonRpcProvider(rpcUrl)
+	const { chainId } = await provider.getNetwork()
+	console.log({ chainId })
+	const filePath = path.join(__dirname, "..", "artifacts", `${chainId}`, "deployment.json")
+	const { address } = JSON.parse(await filesystem.readFile(filePath, { encoding: 'utf8' }))
+	console.log({ address })
+	const code = await provider.getCode(address)
+	const codehash = ethers.utils.keccak256(code)
+	console.log({ codehash, code })
+	if (codehash !== CODEHASH) {
+		throw new Error("unexpected code at Safe singleton factory address")
+	}
+	console.log("OK.")
+}
+
+runScript(verifyDeploymentCode)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 export interface SingletonFactoryInfo {
   gasPrice: number,
-	gasLimit: number,
-	signerAddress: string,
-	transaction: string,
-	address: string
+  gasLimit: number,
+  signerAddress: string,
+  transaction: string,
+  address: string
 }
 
 export const getSingletonFactoryInfo = (chainId: number): SingletonFactoryInfo | undefined => {


### PR DESCRIPTION
This PR adds a new `yarn verify` script that checks deployed bytecode from the RPC configuration. This makes it easier to review PRs for new networks.

As a pro-tip, instead of using a `.env` file and setting the `RPC` in there, you can just invoke the command:

```
RPC=https://example.com yarn verify
```

(Note that the `RPC` variable in the `.env` file **will take precedence**, so make sure to either remove the `.env` file or not set the `RPC` variable in it when using this trick).

Note that this **does not support zkSync based networks at the moment**.

cc @remedcu 
