### PR TITLE
Add GitHub CODEOWNERS Files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @safe-global/safe-protocol


### PR DESCRIPTION
Add a `CODEOWNERS` file so that reviewers automatically get added to PRs.