### PR TITLE
Add A Deployment PR Review Tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ node_modules/
 deployments/
 env/
 .env
-bin/
 ./solc
 coverage/
 coverage.json

--- a/README.md
+++ b/README.md
@@ -77,7 +77,18 @@ To submit a transaction after the deployment data is created:
 
 ## Verifying Networks
 
-In order to verify deployments (when reviewing PRs for example), you can use the `verify` script:
+### Using the `github-review` Tool
+
+This repository contains a bash script [`bin/github-review.sh`](./bin/github-review.sh) for automatically verifying Safe singleton factory deployments to new networks and approving PRs by `$NUMBER`:
+
+- Install [`gh` GitHub CLI tool](https://cli.github.com/)
+- Run `bash bin/github-review.sh $NUMBER`
+
+**Note that this utility does not currently support zkSync-based network deployments**.
+
+### Manual Process
+
+Optionally, the deployment may verified manually with the `verify` NPM script:
 
 - Set `RPC` in the `.env` file for the network.
 - Run `yarn verify`

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Verify a Safe singleton factory deployment PR
+
+This tool wraps the NPM script 'verify' and:
+1. Parses the RPC URL from a GitHub PR and referenced issue
+2. Automatically approves the GitHub PR
+
+USAGE
+    github-review.sh PR
+
+ARGUMENTS
+    PR          The GitHub PR number to review.
+
+EXAMPLES
+    Automatically review Safe singleton factory deployment GitHub PR #42:
+        github-review.sh 42
+EOF
+}
+
+if [[ -f .env ]]; then
+    echo "ERROR: Please remove '.env' file as it interferes with this script" 1>&2
+    exit 1
+fi
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "ERROR: Dirty Git index, please commit all changes before continuing" 1>&2
+    exit 1
+fi
+if ! command -v gh &> /dev/null; then
+    echo "ERROR: Please install the 'gh' GitHub CLI" 1>&2
+    exit 1
+fi
+
+pr=0
+case $# in
+    1)
+        if ! [[ $1 =~ ^[0-9]+$ ]]; then
+            echo "ERROR: $1 is not a valid GitHub PR number" 1>&2
+            usage
+            exit 1
+        fi
+        pr=$1
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac
+
+echo "### Fetching RPC URL"
+issue="$(gh pr view $pr --json body --jq .body | sed -n 's/Fixes #\([0-9]\+\)/\1/p' | head -1)"
+rpc="$(gh issue view $issue | grep -E -o 'https?://[^ ]+' -m 1 | head -1)"
+files="$(gh pr view $pr --json files --jq [.files[].path])"
+echo "=> #$issue: $rpc"
+echo "$files" | jq -r '.[] | "    - \(.)"'
+
+echo "### Verifying Deployment Artifacts"
+gh pr diff $pr --patch | git apply --include 'artifacts/**'
+RPC="$rpc" yarn -s verify
+git clean -fd -- artifacts
+
+echo "### Approving PR"
+approve=1
+if [[ "$(echo "$files" | jq -r .[] | grep -E '^artifacts/[0-9]+/deployment.json$' | wc -l)" -ne 1 ]]; then
+    echo "WARN: Not exactly one deployment artifact changed"
+    approve=0
+fi
+if [[ "$(echo "$files" | jq length)" -ne 1 ]]; then
+    echo "WARN: Non deployment files changed"
+    approve=0
+fi
+if [[ $approve -eq 1 ]]; then
+    gh pr review $pr --approve
+else
+    echo "WARN: Cannot automatically approve"
+fi

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -65,6 +65,11 @@ git clean -fd -- artifacts
 
 echo "### Approving PR"
 approve=1
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "WARN: This PR modified an existing deployment" 1>&2
+    git restore -- artifacts
+    approve=0
+fi
 if [[ "$(echo "$files" | jq -r .[] | grep -E '^artifacts/[0-9]+/deployment.json$' | wc -l)" -ne 1 ]]; then
     echo "WARN: Not exactly one deployment artifact changed"
     approve=0

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -52,7 +52,7 @@ case $# in
 esac
 
 echo "### Fetching RPC URL"
-issue="$(gh pr view $pr --json body --jq .body | sed -n 's/Fixes #\([0-9]\+\)/\1/p' | head -1)"
+issue="$(gh pr view $pr --json body --jq .body | sed -n 's/^.*Fixes #\([0-9][0-9]*\).*$/\1/p' | head -1)"
 rpc="$(gh issue view $issue | grep -E -o 'https?://[^ ]+' -m 1 | head -1)"
 files="$(gh pr view $pr --json files --jq [.files[].path])"
 echo "=> #$issue: $rpc"


### PR DESCRIPTION
This PR builds on #467 by adding a script that automatically verifies a deployment and approves its PR by number.

This allows the protocol team to execute:

```
bash bin/github-review.sh 1337
```

To automatically review a `[New Chain] ...` PR and approve it without interacting with the GitHub UI.