### PR TITLE
Improve Deployment Script Branch Handling

### DIFF
--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -34,6 +34,10 @@ if [[ -f .env ]]; then
     echo "ERROR: Please remove '.env' file as it interferes with this script" 1>&2
     exit 1
 fi
+if [[ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]]; then
+    echo "ERROR: Please run this script from the 'main' branch" 1>&2
+    exit 1
+fi
 if [[ -n "$(git status --porcelain)" ]]; then
     echo "ERROR: Dirty Git index, please commit all changes before continuing" 1>&2
     exit 1
@@ -100,6 +104,8 @@ EOF
 if [[ $commit -eq 1 ]]; then
     git push --set-upstream origin "$issue-github-deployment"
     gh pr create --fill --reviewer safe-global/safe-protocol
+    git checkout main
+    git branch -D "$issue-github-deployment"
 else
     echo "WARN: Cannot automatically create PR" 1>&2
 fi


### PR DESCRIPTION
I typically run this script for multiple GH new chain issues at a time, and this PR makes some minor improvements to the script in order to speed up that process.

In particular, the script now:
- Refuses to run if not starting from the main branch - this is because the automatic PR creation will always try to create a PR from the new branch to `main`, and if we stack some of these deployment PRs, it will create a PR to `main` with multiple unrelated deployments in it as well as not correctly automatically fill the PR description (which requires manual intervention to fix).
- On successful PR creation, delete the deployment branch - this is to cleanup the local git repository after pushing a deployment PR (since it is no longer needed locally) and resets the current branch back to `main` so that it is ready to run for the next deployment (so I don't need to remember to `git checkout main` before running the script for the next new chain issue).

### Test Plan

Created #522  with this script.