### PR TITLE
Add a Small Buffer to the Prefund

### DIFF
--- a/.github/scripts/validate_new_chain_request.sh
+++ b/.github/scripts/validate_new_chain_request.sh
@@ -163,8 +163,10 @@ if jq -e . >/dev/null 2>&1 <<< "$response"; then
     report_error "$ERROR_MSG_PREFUND_CHECK"
   fi
 
-  # We multiply the gas limit by 1.4, just like the deployment script does it
-  gas_limit=$(( gas_limit * 14 / 10 ))
+  # We multiply the gas limit by 1.5, while the deployment script only
+  # multiplies by 1.4. This is to account for gas price fluctuations between the
+  # funding of the account and when the deployment actually happens.
+  gas_limit=$(( gas_limit * 15 / 10 ))
   expected_prefund=$((gas_limit * gas_price))
 
   echo "Expected pre-fund: $expected_prefund"


### PR DESCRIPTION
This PR adds a small buffer to the prefund amount to account for some small fluctuations that may occur in gas price between CI running and checking a new chain issue, and the actual deployment happening.

The value of 1.5 was chosen somewhat arbitrarily.

This is done because we have had two occurrences of this happening recently:
- https://github.com/safe-global/safe-singleton-factory/issues/523
- https://github.com/safe-global/safe-singleton-factory/issues/497