### PR TITLE
Add Block Explorer as a required field to the add chain form

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_chain.yml
+++ b/.github/ISSUE_TEMPLATE/new_chain.yml
@@ -20,6 +20,13 @@ body:
       description: RPC URL
     validations:
       required: true
+  - type: input
+    id: block_explorer
+    attributes:
+      label: Block Explorer
+      description: Block Explorer
+    validations:
+      required: true
   - type: checkboxes
     id: chainlist_url
     attributes:


### PR DESCRIPTION
After a discussion with @tanay1337, we realized that the guide on how to add a new network to Safe mentions the block explorer, while the form does not have a field for it.  So we propose to add a required field to for the block explorer.