### PR TITLE
Fix GitHub Deployment Script `op` Invocation

### DIFF
--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -76,7 +76,7 @@ rpc="$(gh issue view $issue | grep -E -o 'https?://[^ ]+' -m 1 | head -1)"
 echo "=> $rpc"
 
 echo "### Building Deployment Transaction"
-mnemonic="$(op item get "$itemuid" --field password)"
+mnemonic="$(op item get "$itemuid" --field password --reveal)"
 MNEMONIC="$mnemonic" RPC="$rpc" yarn -s estimate-compile
 commit=1
 if [[ -n "$(git status --untracked-files=no --porcelain -- artifacts/)" ]]; then


### PR DESCRIPTION
Recently, the 1Password CLI had a breaking interface [change](https://app-updates.agilebits.com/product_history/CLI2#v2300006) where it now requires the `--reveal` option in order to print secrets.

This PR adds the `--reveal` option where it is needed.