### PR TITLE
Add checkbox to Issue Template for RPC batch request allowance

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_chain.yml
+++ b/.github/ISSUE_TEMPLATE/new_chain.yml
@@ -21,6 +21,13 @@ body:
     validations:
       required: true
   - type: checkboxes
+    id: allow_bacth_request
+    attributes:
+      label: The RPC endpoint must allow batch requests for the bot script.
+      options:
+        - label: I confirm that the RPC allows batch requests
+          required: true
+  - type: checkboxes
     id: chainlist_url
     attributes:
       label: The chain must be added to https://chainlist.org/


### PR DESCRIPTION
Hello

In #774, I encountered an issue where the bot script wasn't functioning as expected.

While debugging the script and checking our environment, I found that the problem was caused by Batch Requests being disabled by default on the Polygon zkEVM RPC.
It would be helpful to add a note in the template indicating that Batch Requests are required.