### PR TITLE
Adding `npm ci`

### DIFF
--- a/.github/workflows/prepare-transaction.yml
+++ b/.github/workflows/prepare-transaction.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run the validation script
         run: |
+          npm ci
           RPC_URL=$(echo "$ISSUE_BODY" | grep -E -o 'https?://[^ ]+' -m 1 | head -1)
           SUMMARY_FILE=summary.json RPC=$RPC_URL npm run verify:new-chain-request || true
           echo "COMMENT_OUTPUT=$(jq -r '.commentOutput' $SUMMARY_FILE)" >> $GITHUB_ENV


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/prepare-transaction.yml` file. The change ensures that the necessary dependencies are installed before running the validation script.

* [`.github/workflows/prepare-transaction.yml`](diffhunk://#diff-8c362f647fafbf3166ca7cece7c26f1b260c5114a3bfcb22c5349230fb2a17f7R19): Added `npm ci` command to install dependencies before running the validation script.