### PR TITLE
Summary file name directly in command

### DIFF
--- a/.github/workflows/prepare-transaction.yml
+++ b/.github/workflows/prepare-transaction.yml
@@ -19,8 +19,8 @@ jobs:
           npm ci
           RPC_URL=$(echo "$ISSUE_BODY" | grep -E -o 'https?://[^ ]+' -m 1 | head -1)
           SUMMARY_FILE=summary.json RPC=$RPC_URL npm run verify:new-chain-request || true
-          echo "COMMENT_OUTPUT=$(jq -r '.commentOutput' $SUMMARY_FILE)" >> $GITHUB_ENV
-          echo "LABEL_OPERATION=$(jq -r '.labelOperation' $SUMMARY_FILE)" >> $GITHUB_ENV
+          echo "COMMENT_OUTPUT=$(jq -r '.commentOutput' summary.json)" >> $GITHUB_ENV
+          echo "LABEL_OPERATION=$(jq -r '.labelOperation' summary.json)" >> $GITHUB_ENV
         env:
           ISSUE_BODY: ${{ env.ISSUE_BODY }}
           FACTORY_ADDRESS: ${{ env.FACTORY_ADDRESS }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/prepare-transaction.yml` file. The change simplifies the environment variable assignment by directly referencing `summary.json` instead of using the `SUMMARY_FILE` variable. 

* [`.github/workflows/prepare-transaction.yml`](diffhunk://#diff-8c362f647fafbf3166ca7cece7c26f1b260c5114a3bfcb22c5349230fb2a17f7L22-R23): Updated the `echo` commands to directly reference `summary.json` for `COMMENT_OUTPUT` and `LABEL_OPERATION`.