### PR TITLE
Bump Version to `v1.0.42`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@safe-global/safe-singleton-factory",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@safe-global/safe-singleton-factory",
-      "version": "1.0.41",
+      "version": "1.0.42",
       "license": "MIT",
       "devDependencies": {
         "@matterlabs/hardhat-zksync-deploy": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-singleton-factory",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "Singleton factory used by Safe related contracts",
   "homepage": "https://github.com/safe-global/safe-singleton-factory/",
   "license": "MIT",


### PR DESCRIPTION
Fixes #967 

This pull request includes a version update for the `@safe-global/safe-singleton-factory` package.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `1.0.41` to `1.0.42`.