### PR TITLE
Small Documentation Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ For example, see the [documentation](https://github.com/wighawag/hardhat-deploy/
 This repository contains a bash script [`bin/github-deploy.sh`](./bin/github-deploy.sh) for automatically deploying the Safe singleton factory for a given GitHub issue `$NUMBER`:
 
 - Install [`gh` GitHub CLI tool](https://cli.github.com/)
-- Install [`op` 1Password CLI tool](https://1password.com/downloads/command-line/)
 - Run `bash bin/github-deploy.sh $NUMBER`
 
 **Note that this utility does not currently support legacy ZKsync based network deployments**.

--- a/scripts/new-chain.ts
+++ b/scripts/new-chain.ts
@@ -192,7 +192,7 @@ class NewChainError extends Error {
 			"Factory pre-deployed",
 			`**📝 Factory already deployed:**<br>` +
 				`Factory is pre-deployed on the chain. Please create a PR adding the artifact to the repository.<br>` +
-				`For more information, see instructions on how to do this in the [README](https://github.com/safe-global/safe-singleton-factory?tab=readme-ov-file#op-stack).`,
+				`For more information, see instructions on how to do this in the [README](https://github.com/safe-global/safe-singleton-factory?tab=readme-ov-file#op-stack-and-zksync-networks).`,
 		);
 	}
 


### PR DESCRIPTION
- Remove `op` CLI documentation from README (since Ledger-based deployments are now the default)
- Fix link to OP Stack and ZKsync documentation for pre-deployed versions of the contracts