### PR TITLE
Use DeFi Llama Chainlist

### DIFF
--- a/scripts/new-chain.ts
+++ b/scripts/new-chain.ts
@@ -157,7 +157,7 @@ async function fetchChainlist() {
 		const status = response.status;
 		const body = await response.text();
 		console.log({ status, body });
-		throw new Error("HTTP ${status} error retrieving chain list.");
+		throw new Error(`HTTP ${status} error retrieving chain list.`);
 	}
 
 	return (await response.json()) as Chainlist;


### PR DESCRIPTION
We require that the chain appears on <https://chainlist.org>, and priviously, this meant that the chain was included in the `ethereum-lists/chains` repository. However, since that repository is no longer actively maintained, and since then DeFi Llama has added mechanisms for "additional chains" to their `DeFiLlama/chainlist` repository, which is the code behind <https://chainlist.org>.

This PR changes our scripts to use the Chainlist.org API for checking if a network is listed or not (instead of the `ethereum-lists/chains` repository).