### PR TITLE
CI Improvements

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,7 +10,7 @@ const config: HardhatUserConfig = {
 		sources: "contracts-zk",
 	},
 	zksolc: {
-		version: "1.3.8", // Use latest available in https://github.com/matter-labs/zksolc-bin/
+		version: "1.3.8",
 		compilerSource: "binary",
 		settings: {
 			isSystem: true,
@@ -20,20 +20,6 @@ const config: HardhatUserConfig = {
 	networks: {
 		hardhat: {
 			zksync: true,
-		},
-		zkSyncTestnet: {
-			url: "https://sepolia.era.zksync.dev",
-			ethNetwork: "sepolia",
-			zksync: true,
-			verifyURL:
-				"https://zksync2-testnet-explorer.zksync.dev/contract_verification",
-		},
-		zkSyncMainnet: {
-			url: "https://mainnet.era.zksync.io",
-			ethNetwork: "mainnet",
-			zksync: true,
-			verifyURL:
-				"https://zksync2-mainnet-explorer.zksync.io/contract_verification",
 		},
 	},
 	solidity: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "ethers": "^5.7.0",
         "hardhat": "^2.12.0",
         "prettier": "^3.6.2",
-        "solc": "0.5.8",
+        "solc": "=0.5.8",
         "ts-node": "^10.9.2",
         "typescript": "^5.5.4",
         "yargs": "^17.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "submit": "ts-node scripts/submit.ts",
     "estimate": "ts-node scripts/estimate.ts",
     "estimate-compile": "ts-node scripts/estimate-compile.ts",
-    "build": "prettier -c . && rimraf dist && tsc",
+    "build": "prettier -c . && tsc -p tsconfig.dev.json && rimraf dist && tsc",
     "fmt": "prettier -w .",
     "prepublish": "npm run build"
   },
@@ -57,7 +57,7 @@
     "ethers": "^5.7.0",
     "hardhat": "^2.12.0",
     "prettier": "^3.6.2",
-    "solc": "0.5.8",
+    "solc": "=0.5.8",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",
     "yargs": "^17.3.1",

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"include": ["hardhat.config.ts", "deploy", "scripts", "src"]
+}


### PR DESCRIPTION
I noticed when developing #1096 that we don't actually typecheck our scripts in CI. This PR adds some adds a new `tsconfig.dev.json` configuration that does not emit code, and lets us typecheck all our sources in CI.

This found a typing error in `hardhat.config.ts`, where `verifierURL` is not a known property. I cleaned up the hardhat configuration a bit (since the network configurations aren't used or needed, and the compiler version is in fact fixed to a historic version, and should not be modified to use the latest available version).