### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: |
+          npm ci
+          npm run build

--- a/.github/workflows/prepare-transaction.yml
+++ b/.github/workflows/prepare-transaction.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Run the validation script
         env:
           SUMMARY_FILE: summary.json

--- a/artifacts/841/deployment.json
+++ b/artifacts/841/deployment.json
@@ -1,7 +1,7 @@
 {
-  "gasPrice": 0,
-  "gasLimit": 0,
-  "signerAddress": "0x0000000000000000000000000000000000000000",
-  "transaction": "0x",
-  "address": "0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7"
+	"gasPrice": 0,
+	"gasLimit": 0,
+	"signerAddress": "0x0000000000000000000000000000000000000000",
+	"transaction": "0x",
+	"address": "0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7"
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "estimate-compile": "ts-node scripts/estimate-compile.ts",
     "build": "prettier -c . && tsc -p tsconfig.dev.json && rimraf dist && tsc",
     "fmt": "prettier -w .",
-    "prepublish": "npm run build"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Two things happened at the same time:
- A deployment was merged that was not correctly formatted
- `prettier -c .` was added to the build step

Since we `build` on `prepublish`, this was causing `npm ci` for installing dependencies to fail in GitHub actions and cause our integrations to stop working.

This PR does a few things:
- Fixes the offending deployment
- Adds a new workflow that is executed in CI on PRs, to prevent mistakes from happening in the future
- Changes `prepublish` to `prepare` as the former was deprecated in favour of the latter ([source](https://docs.npmjs.com/cli/v8/using-npm/scripts#prepare-and-prepublish))

This should make the `prepare_transaction` scripts to start working again.