### PR TITLE
Show Existing PRs in Deployment Script

### DIFF
--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -49,7 +49,11 @@ fi
 issue=0
 case $# in
     0)
-        gh issue list --label ready-to-deploy --json number,title --jq '.[] | "• #\(.number): \(.title)"'
+        gh issue list --label ready-to-deploy \
+            --json number,title,closedByPullRequestsReferences \
+            --jq '.[]
+                  | .pr = (.closedByPullRequestsReferences.[0].number | if (.) then " {✓ #\(.)}" else "" end)
+                  | "• #\(.number): \(.title)\(.pr)"'
         exit 0
         ;;
     1)


### PR DESCRIPTION
This PR adds additional support to the `github-deploy.sh` script so that it shows existing PRs attached to issues to make it easier to identify which networks have already been deployed when there are more than one to process.

Example:

```
• #1237: [New chain]: AB Core Testnet
• #1236: [New chain]: Surge Testnet {✓ #1238}
• #1230: [New chain]: Core Blockchain Testnet2 {✓ #1234}
• #1229: [New chain]: Fluent Testnet {✓ #1233}
• #1227: [New chain]: Kasplex zkEVM Mainnet {✓ #1232}
• #1224: [New chain]: CAPX {✓ #1231}
```